### PR TITLE
Construction of FEInterfaceValues with two pointers

### DIFF
--- a/include/deal.II/fe/fe_interface_values.h
+++ b/include/deal.II/fe/fe_interface_values.h
@@ -1450,6 +1450,14 @@ public:
                     const UpdateFlags               update_flags);
 
   /**
+   * Construct a new FEInterfaceValues on top of two already initialized
+   * FEValuesBase like objects. This may occur when one has
+   *
+   */
+  FEInterfaceValues(FEValuesBase<dim, spacedim> *const fe_values0,
+                    FEValuesBase<dim, spacedim> *const fe_values1);
+
+  /**
    * Re-initialize this object to be used on a new interface given by two faces
    * of two neighboring cells. The `cell` and `cell_neighbor` cells will be
    * referred to through `cell_index` zero and one after this call in all places
@@ -1546,13 +1554,13 @@ public:
          const unsigned int      fe_index      = numbers::invalid_unsigned_int);
 
   /**
-   * Return a reference to the FEFaceValues or FESubfaceValues object
+   * Return a reference to the FEValuesBase object
    * of the specified cell of the interface.
    *
    * The @p cell_index is either 0 or 1 and corresponds to the cell index
    * returned by interface_dof_to_cell_and_dof_index().
    */
-  const FEFaceValuesBase<dim, spacedim> &
+  const FEValuesBase<dim, spacedim> &
   get_fe_face_values(const unsigned int cell_index) const;
 
   /**
@@ -2203,14 +2211,14 @@ private:
    * Pointer to internal_fe_face_values or internal_fe_subface_values,
    * respectively as determined in reinit().
    */
-  FEFaceValuesBase<dim, spacedim> *fe_face_values;
+  FEValuesBase<dim, spacedim> *fe_face_values;
 
   /**
    * Pointer to internal_fe_face_values_neighbor,
    * internal_fe_subface_values_neighbor, or nullptr, respectively
    * as determined in reinit().
    */
-  FEFaceValuesBase<dim, spacedim> *fe_face_values_neighbor;
+  FEValuesBase<dim, spacedim> *fe_face_values_neighbor;
 
   /**
    * @name Data that supports the standard FE implementation
@@ -2441,6 +2449,33 @@ FEInterfaceValues<dim, spacedim>::FEInterfaceValues(
 
 
 template <int dim, int spacedim>
+FEInterfaceValues<dim, spacedim>::FEInterfaceValues(
+  FEValuesBase<dim, spacedim> *const fe_values0,
+  FEValuesBase<dim, spacedim> *const fe_values1)
+  : n_quadrature_points(fe_values0->get_quadrature_points().size())
+  , fe_face_values(fe_values0)
+  , fe_face_values_neighbor(fe_values1)
+  , internal_fe_face_values(nullptr)
+  , internal_fe_subface_values(nullptr)
+  , internal_fe_face_values_neighbor(nullptr)
+  , internal_fe_subface_values_neighbor(nullptr)
+{
+  
+  Assert(
+    !(dynamic_cast<FEFaceValuesBase<dim, spacedim> *const>(fe_values0) &&
+      dynamic_cast<FEFaceValuesBase<dim, spacedim> *const>(fe_values1)),
+    ExcMessage(
+      "This constructor should not be used with FEFaceValues like objects, use the standard constructor instead."));
+  Assert(
+    (fe_values0->get_quadrature_points().size() ==
+     fe_values1->get_quadrature_points().size()),
+    ExcMessage(
+      "The number of quadrature points from the two sides is not the same."));
+}
+
+
+
+template <int dim, int spacedim>
 template <class CellIteratorType, class CellNeighborIteratorType>
 void
 FEInterfaceValues<dim, spacedim>::reinit(
@@ -2454,7 +2489,8 @@ FEInterfaceValues<dim, spacedim>::reinit(
   const unsigned int              mapping_index,
   const unsigned int              fe_index)
 {
-  Assert(internal_fe_face_values || internal_hp_fe_face_values,
+  Assert(internal_fe_face_values || internal_hp_fe_face_values ||
+           fe_face_values || fe_face_values_neighbor,
          ExcNotInitialized());
 
   if (internal_fe_face_values)
@@ -2466,6 +2502,11 @@ FEInterfaceValues<dim, spacedim>::reinit(
         }
       else
         {
+          Assert(
+            internal_fe_subface_values,
+            ExcMessage(
+              "You provided a subface index, but this doesn't make sense for the kind of FEValues you passed."));
+
           internal_fe_subface_values->reinit(cell, face_no, sub_face_no);
           fe_face_values = internal_fe_subface_values.get();
         }
@@ -2477,6 +2518,10 @@ FEInterfaceValues<dim, spacedim>::reinit(
         }
       else
         {
+          Assert(
+            internal_fe_subface_values_neighbor,
+            ExcMessage(
+              "You provided a subface index, but this doesn't make sense for the kind of FEValues you passed."));
           internal_fe_subface_values_neighbor->reinit(cell_neighbor,
                                                       face_no_neighbor,
                                                       sub_face_no_neighbor);
@@ -2859,7 +2904,7 @@ FEInterfaceValues<dim, spacedim>::interface_dof_to_dof_indices(
 
 
 template <int dim, int spacedim>
-const FEFaceValuesBase<dim, spacedim> &
+const FEValuesBase<dim, spacedim> &
 FEInterfaceValues<dim, spacedim>::get_fe_face_values(
   const unsigned int cell_index) const
 {

--- a/tests/feinterface/fe_interface_values_13.cc
+++ b/tests/feinterface/fe_interface_values_13.cc
@@ -1,0 +1,257 @@
+// ---------------------------------------------------------------------
+
+// Copyright (C) 2018 - 2021 by the deal.II authors
+
+// This file is part of the deal.II library.
+
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE.md at
+// the top level directory of deal.II.
+
+// ---------------------------------------------------------------------
+
+
+// evaluate jump_in_shape_values(), average_of_shape_values(), shape_value() of
+// FEInterfaceValues
+
+#include <deal.II/base/quadrature_lib.h>
+
+#include <deal.II/fe/fe_dgq.h>
+#include <deal.II/fe/fe_interface_values.h>
+#include <deal.II/fe/fe_nothing.h>
+#include <deal.II/fe/fe_values.h>
+#include <deal.II/fe/mapping_q.h>
+
+#include <deal.II/grid/grid_generator.h>
+#include <deal.II/grid/grid_refinement.h>
+#include <deal.II/grid/tria.h>
+
+#include <deal.II/non_matching/fe_immersed_values.h>
+
+#include <fstream>
+#include <iostream>
+
+#include "../tests.h"
+
+template <int dim>
+void
+make_2_cells(Triangulation<dim> &tria);
+
+template <>
+void
+make_2_cells<2>(Triangulation<2> &tria)
+{
+  const unsigned int        dim         = 2;
+  std::vector<unsigned int> repetitions = {2, 1};
+  Point<dim>                p1;
+  Point<dim>                p2(2.0, 1.0);
+
+  GridGenerator::subdivided_hyper_rectangle(tria, repetitions, p1, p2);
+}
+
+template <>
+void
+make_2_cells<3>(Triangulation<3> &tria)
+{
+  const unsigned int        dim         = 3;
+  std::vector<unsigned int> repetitions = {2, 1, 1};
+  Point<dim>                p1;
+  Point<dim>                p2(2.0, 1.0, 1.0);
+
+  GridGenerator::subdivided_hyper_rectangle(tria, repetitions, p1, p2);
+}
+
+
+template <int dim>
+std::pair<std::vector<Point<dim>>, std::vector<double>>
+rescale(const typename Triangulation<dim>::active_cell_iterator &cell,
+        const MappingQ<dim> &                                    mapping,
+        std::vector<Point<dim>> &                                q_points,
+        std::vector<double> &                                    JxWs,
+        std::vector<Tensor<1, dim>> &                            normals)
+{
+  const auto &            bbox         = mapping.get_bounding_box(cell);
+  const double            bbox_measure = bbox.volume();
+  std::vector<Point<dim>> unit_q_points;
+
+  std::transform(q_points.begin(),
+                 q_points.end(),
+                 std::back_inserter(unit_q_points),
+                 [&](const Point<dim> &p) {
+                   return mapping.transform_real_to_unit_cell(cell, p);
+                 });
+
+  // Weights must be scaled with det(J)*|J^-t n| for each quadrature point.
+  // Use the fact that we are using a BBox, so the jacobi entries are the
+  // side_length in each direction and normals are already available at this
+  // point.
+  std::vector<double> scale_factors(q_points.size());
+  std::vector<double> scaled_weights(q_points.size());
+  Tensor<1, dim>      scale;
+
+  for (unsigned int q = 0; q < q_points.size(); ++q)
+    {
+      for (unsigned int direction = 0; direction < dim; ++direction)
+        {
+          scale[direction] =
+            normals[q][direction] / (bbox.side_length(direction));
+        }
+
+      scaled_weights[q] = JxWs[q] / (bbox_measure * scale.norm());
+    }
+
+  std::pair<std::vector<Point<dim>>, std::vector<double>> my_p(unit_q_points,
+                                                               scaled_weights);
+  return my_p;
+}
+
+
+template <int dim>
+void
+inspect_fiv(FEInterfaceValues<dim> &fiv)
+{
+  deallog << "at_boundary(): " << fiv.at_boundary() << "\n"
+          << "n_current_interface_dofs(): " << fiv.n_current_interface_dofs()
+          << "\n";
+
+  std::vector<types::global_dof_index> indices =
+    fiv.get_interface_dof_indices();
+  Assert(indices.size() == fiv.n_current_interface_dofs(), ExcInternalError());
+
+  deallog << "interface_dof_indices: ";
+  for (auto i : indices)
+    deallog << i << ' ';
+  deallog << "\n";
+
+  unsigned int idx = 0;
+  for (auto v : indices)
+    {
+      deallog << "  index " << idx << " global_dof_index:" << v << ":\n";
+
+      const auto pair = fiv.interface_dof_to_dof_indices(idx);
+      deallog << "    dof indices: " << static_cast<int>(pair[0]) << " | "
+              << static_cast<int>(pair[1]) << "\n";
+
+      ++idx;
+    }
+
+  deallog << std::endl;
+}
+
+
+template <int dim>
+void
+test(unsigned int fe_degree)
+{
+  Triangulation<dim> tria;
+  make_2_cells(tria);
+
+  DoFHandler<dim> dofh(tria);
+  FE_DGQ<dim>     fe(fe_degree);
+  deallog << fe.get_name() << std::endl;
+  dofh.distribute_dofs(fe);
+
+  MappingQ<dim> mapping(1);
+  UpdateFlags   update_flags = update_values | update_gradients |
+                             update_quadrature_points | update_normal_vectors |
+                             update_JxW_values;
+  FEFaceValues<dim> no_values(mapping,
+                              fe,
+                              QGauss<dim - 1>(fe_degree + 1),
+                              update_flags); // only for quadrature
+
+  auto cell = dofh.begin();
+
+  for (const unsigned int f : GeometryInfo<dim>::face_indices())
+    if (!cell->at_boundary(f))
+      {
+        no_values.reinit(cell, f);
+        auto q_points = no_values.get_quadrature_points();
+        auto JxWs     = no_values.get_JxW_values();
+        auto normals  = no_values.get_normal_vectors();
+
+        NonMatching::FEImmersedSurfaceValues<dim> fe0(
+          mapping,
+          fe,
+          NonMatching::ImmersedSurfaceQuadrature<dim>(q_points, JxWs, normals),
+          update_flags);
+
+        no_values.reinit(cell->neighbor(f), cell->neighbor_of_neighbor(f));
+        q_points = no_values.get_quadrature_points();
+        JxWs     = no_values.get_JxW_values();
+        normals  = no_values.get_normal_vectors();
+
+        NonMatching::FEImmersedSurfaceValues<dim> fe1(
+          mapping,
+          fe,
+          NonMatching::ImmersedSurfaceQuadrature<dim>(q_points, JxWs, normals),
+          update_flags);
+
+        fe0.reinit(cell);
+        fe1.reinit(cell->neighbor(f));
+
+        FEInterfaceValues<dim> fiv(&fe0, &fe1);
+        fiv.reinit(cell,
+                   f,
+                   numbers::invalid_unsigned_int,
+                   cell->neighbor(f),
+                   cell->neighbor_of_neighbor(f),
+                   numbers::invalid_unsigned_int);
+
+        inspect_fiv(fiv);
+        for (const auto &p : fiv.get_quadrature_points())
+          deallog << p << std::endl;
+        for (const auto &n : fiv.get_normal_vectors())
+          deallog << n << std::endl;
+        const unsigned int n_dofs = fiv.n_current_interface_dofs();
+        Vector<double>     cell_vector(n_dofs);
+
+        q_points = fiv.get_quadrature_points();
+        for (unsigned int qpoint = 0; qpoint < q_points.size(); ++qpoint)
+          deallog << "qpoint " << qpoint << ": " << q_points[qpoint]
+                  << std::endl;
+
+        cell_vector = 0.0;
+        for (unsigned int qpoint = 0; qpoint < q_points.size(); ++qpoint)
+          for (unsigned int i = 0; i < n_dofs; ++i)
+            cell_vector(i) +=
+              fiv.shape_value(true, i, qpoint) * fiv.get_JxW_values()[qpoint];
+        deallog << "shape_value(true): " << cell_vector << std::endl;
+
+        cell_vector = 0.0;
+        for (unsigned int qpoint = 0; qpoint < q_points.size(); ++qpoint)
+          for (unsigned int i = 0; i < n_dofs; ++i)
+            cell_vector(i) +=
+              fiv.shape_value(false, i, qpoint) * fiv.get_JxW_values()[qpoint];
+        deallog << "shape_value(false): " << cell_vector << std::endl;
+
+        cell_vector = 0.0;
+        for (unsigned int qpoint = 0; qpoint < q_points.size(); ++qpoint)
+          for (unsigned int i = 0; i < n_dofs; ++i)
+            cell_vector(i) += fiv.jump_in_shape_values(i, qpoint) *
+                              fiv.get_JxW_values()[qpoint];
+        deallog << "jump_in_shape_values(): " << cell_vector << std::endl;
+
+        cell_vector = 0.0;
+        for (unsigned int qpoint = 0; qpoint < q_points.size(); ++qpoint)
+          for (unsigned int i = 0; i < n_dofs; ++i)
+            cell_vector(i) += fiv.average_of_shape_values(i, qpoint) *
+                              fiv.get_JxW_values()[qpoint];
+        deallog << "average_of_shape_values(): " << cell_vector << std::endl;
+      }
+}
+
+
+
+int
+main()
+{
+  initlog();
+  test<2>(0);
+  test<2>(1);
+  test<3>(0);
+  test<3>(1);
+}

--- a/tests/feinterface/fe_interface_values_13.output
+++ b/tests/feinterface/fe_interface_values_13.output
@@ -1,0 +1,117 @@
+
+DEAL::FE_DGQ<2>(0)
+DEAL::at_boundary(): 0
+n_current_interface_dofs(): 2
+interface_dof_indices: 0 1 
+  index 0 global_dof_index:0:
+    dof indices: 0 | -1
+  index 1 global_dof_index:1:
+    dof indices: -1 | 0
+
+DEAL::1.00000 0.500000
+DEAL::1.00000 0.00000
+DEAL::qpoint 0: 1.00000 0.500000
+DEAL::shape_value(true): 1.00000 0.00000
+DEAL::shape_value(false): 0.00000 1.00000
+DEAL::jump_in_shape_values(): 1.00000 -1.00000
+DEAL::average_of_shape_values(): 0.500000 0.500000
+DEAL::FE_DGQ<2>(1)
+DEAL::at_boundary(): 0
+n_current_interface_dofs(): 8
+interface_dof_indices: 0 1 2 3 4 5 6 7 
+  index 0 global_dof_index:0:
+    dof indices: 0 | -1
+  index 1 global_dof_index:1:
+    dof indices: 1 | -1
+  index 2 global_dof_index:2:
+    dof indices: 2 | -1
+  index 3 global_dof_index:3:
+    dof indices: 3 | -1
+  index 4 global_dof_index:4:
+    dof indices: -1 | 0
+  index 5 global_dof_index:5:
+    dof indices: -1 | 1
+  index 6 global_dof_index:6:
+    dof indices: -1 | 2
+  index 7 global_dof_index:7:
+    dof indices: -1 | 3
+
+DEAL::1.00000 0.211325
+DEAL::1.00000 0.788675
+DEAL::1.00000 0.00000
+DEAL::1.00000 0.00000
+DEAL::qpoint 0: 1.00000 0.211325
+DEAL::qpoint 1: 1.00000 0.788675
+DEAL::shape_value(true): 0.00000 0.500000 0.00000 0.500000 0.00000 0.00000 0.00000 0.00000
+DEAL::shape_value(false): 0.00000 0.00000 0.00000 0.00000 0.00000 0.500000 0.00000 0.500000
+DEAL::jump_in_shape_values(): 0.00000 0.500000 0.00000 0.500000 0.00000 -0.500000 0.00000 -0.500000
+DEAL::average_of_shape_values(): 0.00000 0.250000 0.00000 0.250000 0.00000 0.250000 0.00000 0.250000
+DEAL::FE_DGQ<3>(0)
+DEAL::at_boundary(): 0
+n_current_interface_dofs(): 2
+interface_dof_indices: 0 1 
+  index 0 global_dof_index:0:
+    dof indices: 0 | -1
+  index 1 global_dof_index:1:
+    dof indices: -1 | 0
+
+DEAL::1.00000 0.500000 0.500000
+DEAL::1.00000 0.00000 0.00000
+DEAL::qpoint 0: 1.00000 0.500000 0.500000
+DEAL::shape_value(true): 1.00000 0.00000
+DEAL::shape_value(false): 0.00000 1.00000
+DEAL::jump_in_shape_values(): 1.00000 -1.00000
+DEAL::average_of_shape_values(): 0.500000 0.500000
+DEAL::FE_DGQ<3>(1)
+DEAL::at_boundary(): 0
+n_current_interface_dofs(): 16
+interface_dof_indices: 0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 
+  index 0 global_dof_index:0:
+    dof indices: 0 | -1
+  index 1 global_dof_index:1:
+    dof indices: 1 | -1
+  index 2 global_dof_index:2:
+    dof indices: 2 | -1
+  index 3 global_dof_index:3:
+    dof indices: 3 | -1
+  index 4 global_dof_index:4:
+    dof indices: 4 | -1
+  index 5 global_dof_index:5:
+    dof indices: 5 | -1
+  index 6 global_dof_index:6:
+    dof indices: 6 | -1
+  index 7 global_dof_index:7:
+    dof indices: 7 | -1
+  index 8 global_dof_index:8:
+    dof indices: -1 | 0
+  index 9 global_dof_index:9:
+    dof indices: -1 | 1
+  index 10 global_dof_index:10:
+    dof indices: -1 | 2
+  index 11 global_dof_index:11:
+    dof indices: -1 | 3
+  index 12 global_dof_index:12:
+    dof indices: -1 | 4
+  index 13 global_dof_index:13:
+    dof indices: -1 | 5
+  index 14 global_dof_index:14:
+    dof indices: -1 | 6
+  index 15 global_dof_index:15:
+    dof indices: -1 | 7
+
+DEAL::1.00000 0.211325 0.211325
+DEAL::1.00000 0.788675 0.211325
+DEAL::1.00000 0.211325 0.788675
+DEAL::1.00000 0.788675 0.788675
+DEAL::1.00000 0.00000 5.55112e-17
+DEAL::1.00000 0.00000 0.00000
+DEAL::1.00000 0.00000 5.55112e-17
+DEAL::1.00000 0.00000 0.00000
+DEAL::qpoint 0: 1.00000 0.211325 0.211325
+DEAL::qpoint 1: 1.00000 0.788675 0.211325
+DEAL::qpoint 2: 1.00000 0.211325 0.788675
+DEAL::qpoint 3: 1.00000 0.788675 0.788675
+DEAL::shape_value(true): 4.62593e-18 0.250000 1.72642e-17 0.250000 1.23951e-18 0.250000 4.62593e-18 0.250000 0.00000 0.00000 0.00000 0.00000 0.00000 0.00000 0.00000 0.00000
+DEAL::shape_value(false): 0.00000 0.00000 0.00000 0.00000 0.00000 0.00000 0.00000 0.00000 4.62593e-18 0.250000 1.72642e-17 0.250000 1.23951e-18 0.250000 4.62593e-18 0.250000
+DEAL::jump_in_shape_values(): 4.62593e-18 0.250000 1.72642e-17 0.250000 1.23951e-18 0.250000 4.62593e-18 0.250000 -4.62593e-18 -0.250000 -1.72642e-17 -0.250000 -1.23951e-18 -0.250000 -4.62593e-18 -0.250000
+DEAL::average_of_shape_values(): 2.31296e-18 0.125000 8.63210e-18 0.125000 6.19757e-19 0.125000 2.31296e-18 0.125000 2.31296e-18 0.125000 8.63210e-18 0.125000 6.19757e-19 0.125000 2.31296e-18 0.125000

--- a/tests/feinterface/step-12.cc
+++ b/tests/feinterface/step-12.cc
@@ -300,7 +300,7 @@ namespace Step12
                                ScratchData<dim> &  scratch_data,
                                CopyData &          copy_data) {
       scratch_data.fe_interface_values.reinit(cell, face_no);
-      const FEFaceValuesBase<dim> &fe_face =
+      const FEValuesBase<dim> &fe_face =
         scratch_data.fe_interface_values.get_fe_face_values(0);
 
       const auto &q_points = fe_face.get_quadrature_points();


### PR DESCRIPTION
This PR allows to construct a `FEInterfaceValues` out of two pointers to already initialized FEValues objects. It's working for our application, but right now I'm not sure this is what you intended.
First, the only context I can imagine this is when one has two `ImmersedQuadrature`s  (and hence two different `FEImmersedSurfaceValues` on two neighboring cells) and needs to compute jumps, etc. The issue with this is that a FEImmersedSurfaceValues is an FEValuesBase, not a FEFaceValuesBase and as such we don't have `reinit(cell,f)`), so the two internal pointers have been changed to plain FEValuesBase. 

Second, the `reinit` of FEInterfaceValues allows also for subfaces in principle, but this is not allowed with an `FEImmersedSurfaceValues`, so these two Asserts for subfaces

https://github.com/luca-heltai/dealii/blob/219070098e3f360ca8e5108baa7172c716134c79/include/deal.II/fe/fe_interface_values.h#L2505-L2506

https://github.com/luca-heltai/dealii/blob/219070098e3f360ca8e5108baa7172c716134c79/include/deal.II/fe/fe_interface_values.h#L2521-L2522

are necessary in case one accidentally calls reinit with subfaces arguments using this constructor.


@luca-heltai 